### PR TITLE
Handle form submissions via email

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "cors": "^2.8.5",
         "express": "^4.19.2",
         "i18n": "^0.15.1",
+        "nodemailer": "^6.9.13",
         "vue": "^3.5.13",
         "vue-i18n": "^11.1.9",
         "vue-router": "^4.5.1",
@@ -2928,6 +2929,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/npm-run-path": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "vue": "^3.5.13",
     "vue-i18n": "^11.1.9",
     "vue-router": "^4.5.1",
-    "vue3-social-sharing": "^1.4.1"
+    "vue3-social-sharing": "^1.4.1",
+    "nodemailer": "^6.9.13"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.1",

--- a/server.js
+++ b/server.js
@@ -1,46 +1,38 @@
 import express from 'express';
 import cors from 'cors';
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import nodemailer from 'nodemailer';
 const app = express();
 app.use(cors());
 const port = process.env.PORT || 3001;
 
 app.use(express.json());
 
-const dataDir = path.join(__dirname, 'data');
-fs.mkdirSync(dataDir, { recursive: true });
-
-function appendToFile(fileName, entry) {
-  const filePath = path.join(dataDir, fileName);
-  let list = [];
-  if (fs.existsSync(filePath)) {
-    try {
-      list = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-    } catch (_) {
-      list = [];
-    }
-  }
-  list.push({ ...entry, receivedAt: new Date().toISOString() });
-  fs.writeFileSync(filePath, JSON.stringify(list, null, 2));
-}
-
-app.post('/api/contact', (req, res) => {
-  try {
-    appendToFile('contacts.json', req.body);
-    res.json({ success: true });
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ success: false });
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST,
+  port: process.env.SMTP_PORT,
+  secure: process.env.SMTP_SECURE === 'true',
+  auth: {
+    user: process.env.SMTP_USER,
+    pass: process.env.SMTP_PASS
   }
 });
 
-app.post('/api/quote', (req, res) => {
+app.post('/api/receive', async (req, res) => {
+  const { type, ...payload } = req.body || {};
+  if (!type || (type !== 'contact' && type !== 'quote')) {
+    res.status(400).json({ success: false });
+    return;
+  }
+
+  const mailOptions = {
+    from: process.env.MAIL_FROM || 'no-reply@agrobots.ai',
+    to: 'info@agrobots.ai',
+    subject: type === 'quote' ? 'New Quote Request' : 'New Contact Request',
+    text: JSON.stringify(payload, null, 2)
+  };
+
   try {
-    appendToFile('quotes.json', req.body);
+    await transporter.sendMail(mailOptions);
     res.json({ success: true });
   } catch (err) {
     console.error(err);

--- a/src/components/QuoteBuilder.vue
+++ b/src/components/QuoteBuilder.vue
@@ -243,10 +243,10 @@ export default {
     async submitQuote() {
       if (!this.validateStep()) return;
       try {
-        await fetch('/api/quote', {
+        await fetch('/api/receive', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(this.form)
+          body: JSON.stringify({ type: 'quote', ...this.form })
         });
       } catch (err) {
         console.error(err);

--- a/src/components/subcomponents/Contact.vue
+++ b/src/components/subcomponents/Contact.vue
@@ -34,10 +34,10 @@
       },
       async sendForm() {
         try {
-          const res = await fetch('/api/contact', {
+          const res = await fetch('/api/receive', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(this.form)
+            body: JSON.stringify({ type: 'contact', ...this.form })
           });
           if (!res.ok) throw new Error('Request failed');
           this.submitted = true;


### PR DESCRIPTION
## Summary
- add nodemailer dependency
- replace file logging with email sending
- consolidate contact and quote endpoints to `/api/receive`
- update frontend components to post to new endpoint

## Testing
- `npm run build`
- `npm run server` (manual stop via Ctrl+C)

------
https://chatgpt.com/codex/tasks/task_e_68765f61138c8327956c107be40cde81