### PR TITLE
Add Agrobots intro slide, news ticker/modal, and refactor VideoFeature

### DIFF
--- a/src/components/AgrobotsIntro.vue
+++ b/src/components/AgrobotsIntro.vue
@@ -1,0 +1,62 @@
+<template>
+  <section class="agrobots-intro">
+    <div class="intro-panel">
+      <h1>{{ slideTitle }}</h1>
+      <div class="intro-copy">
+        <p v-for="(paragraph, index) in introText" :key="index">{{ paragraph }}</p>
+      </div>
+    </div>
+
+    <aside class="intro-images" aria-label="Agrobots visuals">
+      <img v-for="(image, index) in images" :key="index" :src="image.src" :alt="image.alt" />
+    </aside>
+  </section>
+</template>
+
+<script>
+export default {
+  name: 'AgrobotsIntro',
+  props: {
+    slideTitle: { type: String, required: true },
+    introText: { type: Array, required: true },
+    images: { type: Array, default: () => [] }
+  }
+};
+</script>
+
+<style scoped>
+.agrobots-intro {
+  display: grid;
+  grid-template-columns: minmax(0, 1.3fr) minmax(280px, .7fr);
+  gap: 1.5rem;
+  width: 100%;
+  height: 100%;
+  padding: 1.5rem;
+  box-sizing: border-box;
+}
+.intro-panel {
+  background: var(--backgroundDarkTranslucent, rgba(18, 18, 18, .9));
+  border-radius: 16px;
+  padding: 1.5rem 1.8rem;
+  overflow-y: auto;
+}
+.intro-panel h1 { margin-top: 0; }
+.intro-copy { display: flex; flex-direction: column; gap: .85rem; line-height: 1.6; }
+.intro-copy p { margin: 0; }
+.intro-images {
+  display: grid;
+  gap: 1rem;
+  grid-auto-rows: minmax(160px, 1fr);
+}
+.intro-images img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, .2);
+}
+@media (max-width: 980px) {
+  .agrobots-intro { grid-template-columns: 1fr; }
+  .intro-images { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+</style>

--- a/src/components/SlideDeck.vue
+++ b/src/components/SlideDeck.vue
@@ -77,6 +77,9 @@
 
     <footer class="app-footer">
       <div class="footer-cta-row">
+        <button class="footer-news-ticker" @click="toggleNewsModal">
+          <span class="ticker-track">{{ tickerText }}</span>
+        </button>
         <button @click="toggleContact" class="footer-cta contact-cta">
 
           {{ $t('footer.contact') }}
@@ -100,19 +103,45 @@
           @sent="toggleContact"
       />
     </div>
+
+    <teleport to="body">
+      <div v-if="newsModalVisible" class="news-list-modal" @click.self="toggleNewsModal">
+        <div class="news-list-content">
+          <button class="news-list-close" @click="toggleNewsModal" aria-label="Close news">×</button>
+          <h2 class="news-list-title">Agrobots News</h2>
+          <ul class="news-list-items">
+            <li v-for="item in footerNewsItems" :key="item.title + item.date">
+              <button class="news-list-item-btn" @click="openNewsArticle(item)">
+                <span class="item-title">{{ item.title }}</span>
+                <span class="item-meta">{{ item.date }} · {{ item.location }}</span>
+              </button>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </teleport>
+
+    <NewsArticleModal
+        :visible="newsArticleModalVisible"
+        :article="activeNewsItem"
+        @close="closeNewsArticle"
+    />
   </div>
 </template>
 
 <script>
 import VideoFeature from './VideoFeature.vue';
+import AgrobotsIntro from './AgrobotsIntro.vue';
 import CardGrid from './CardGrid.vue';
 import ScrollingFullBg from './ScrollingFullBg.vue';
 import ConnectionCircles from './ConnectionCircles.vue';
 import Contact from './subcomponents/Contact.vue';
+import NewsArticleModal from './subcomponents/NewsArticleModal.vue';
 import ActionColumns from "@/components/ActionColumns.vue";
 import i18n from '@/i18n/index.js';
 
 import introSlide from '../slides/intro.js';
+import agrobotsSlide from '../slides/agrobots.js';
 import issueSlide from '../slides/issue.js';
 import servicesSlide from '../slides/services.js';
 import bioromeSlide from '../slides/biorome.js';
@@ -128,17 +157,20 @@ export default {
   name: 'AgrobotsMiniSite',
   components: {
     VideoFeature,
+    AgrobotsIntro,
     CardGrid,
     ScrollingFullBg,
     ConnectionCircles,
     ActionColumns,
-    Contact
+    Contact,
+    NewsArticleModal
   },
   data() {
     return {
       currentSlide: 0,
       slides: [
         introSlide,
+        agrobotsSlide,
         issueSlide,
         visionSlide,
         bioromeSlide,
@@ -152,6 +184,9 @@ export default {
       ],
       menuOpen: false,
       contactVisible: false,
+      newsModalVisible: false,
+      newsArticleModalVisible: false,
+      activeNewsItem: null,
       currentLang: i18n.global.locale.value,
       showLangMenu: false,
       availableLangs: ['en', 'es']
@@ -167,11 +202,19 @@ export default {
   },
   computed: {
     componentEventMap() {
-      const compName = this.slides[this.currentSlide].component;
+      if (this.slides[this.currentSlide].name === 'intro') {
+        return { next: this.nextSlide };
+      }
       if (this.slides[this.currentSlide].name === 'participate') {
         return { contact: this.toggleContact };
       }
       return {};
+    },
+    footerNewsItems() {
+      return introSlide.content[this.currentLang]?.newsItems || [];
+    },
+    tickerText() {
+      return this.footerNewsItems.map(item => item.title).join('  •  ');
     }
   },
   methods: {
@@ -192,6 +235,17 @@ export default {
     },
     toggleContact() {
       this.contactVisible = !this.contactVisible;
+    },
+    toggleNewsModal() {
+      this.newsModalVisible = !this.newsModalVisible;
+    },
+    openNewsArticle(item) {
+      this.activeNewsItem = item;
+      this.newsArticleModalVisible = true;
+    },
+    closeNewsArticle() {
+      this.newsArticleModalVisible = false;
+      this.activeNewsItem = null;
     },
     selectLang(lang) {
       this.currentLang = lang;
@@ -252,6 +306,83 @@ export default {
   overflow: hidden;
   position: relative;
 }
+
+.footer-news-ticker {
+  flex: 1;
+  min-width: 0;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 999px;
+  background: rgba(8, 8, 8, 0.4);
+  color: #fff;
+  overflow: hidden;
+  height: 38px;
+  cursor: pointer;
+  position: relative;
+}
+
+.ticker-track {
+  display: inline-block;
+  white-space: nowrap;
+  padding-left: 100%;
+  animation: ticker 32s linear infinite;
+  font-size: 0.84rem;
+}
+
+@keyframes ticker {
+  from { transform: translateX(0); }
+  to { transform: translateX(-100%); }
+}
+
+.news-list-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(8, 8, 8, 0.85);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 2020;
+  padding: 1rem;
+}
+
+.news-list-content {
+  width: min(90vw, 900px);
+  max-height: 85vh;
+  overflow-y: auto;
+  background: rgba(19, 19, 19, 0.96);
+  border-radius: 16px;
+  padding: 1.5rem 1.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  position: relative;
+}
+
+.news-list-close {
+  position: absolute;
+  right: 14px;
+  top: 10px;
+  border: none;
+  background: transparent;
+  color: #fff;
+  font-size: 1.8rem;
+  cursor: pointer;
+}
+
+.news-list-title { margin: 0 0 1rem 0; }
+.news-list-items { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: .65rem; }
+.news-list-item-btn {
+  width: 100%;
+  text-align: left;
+  border: 1px solid rgba(255,255,255,.16);
+  border-radius: 10px;
+  padding: .75rem .8rem;
+  background: rgba(255,255,255,.04);
+  color: #fff;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: .25rem;
+}
+.item-title { font-weight: 600; }
+.item-meta { font-size: .78rem; opacity: .76; }
 
 .main-stage {
   display: flex;

--- a/src/components/VideoFeature.vue
+++ b/src/components/VideoFeature.vue
@@ -9,136 +9,76 @@
       <div class="hero-content-grid">
         <div class="hero-primary-column">
           <div class="hero-intro-text">
+            <div class="intro-kicker">{{ title }}</div>
+            <h2 class="welcome-title">{{ introTitle }}</h2>
+            <p class="welcome-text">{{ welcomeText }}</p>
+            <p v-if="welcomeHint" class="welcome-hint">{{ welcomeHint }}</p>
+
             <section class="hero-media-inline" aria-label="Intro video">
               <div class="video-card" @click="openModal">
                 <img :src="thumbnail" alt="Play video" />
                 <span class="yt-play-btn"></span>
               </div>
             </section>
-            <div class="intro-text-body">
-              <p v-for="(text, index) in introText" :key="index">{{ text }}</p>
+
+            <div class="hero-actions">
+              <button type="button" class="primary-action" @click="$emit('next')">
+                {{ nextLabel }}
+              </button>
             </div>
           </div>
         </div>
-
-        <section
-            v-if="displayedNewsItems.length"
-            class="news-panel"
-            aria-label="News feed"
-        >
-          <div class="news-panel-header">
-            <h2 class="news-panel-title">{{ newsTitle }}</h2>
-          </div>
-          <ul class="news-list">
-            <li
-                v-for="item in displayedNewsItems"
-                :key="item.title + item.date"
-                class="news-item"
-                role="button"
-                tabindex="0"
-                @click="openNewsModal(item)"
-                @keyup.enter="openNewsModal(item)"
-                @keyup.space.prevent="openNewsModal(item)"
-            >
-              <div class="news-meta">
-                <div class="news-meta-left">
-                  <span v-if="item.tag" class="news-tag">{{ item.tag }}</span>
-                </div>
-                <div class="news-meta-right">
-                  <span class="news-date">{{ item.date }}</span>
-                  <span v-if="item.location" class="news-location">{{ item.location }}</span>
-                </div>
-              </div>
-              <h3 class="news-item-title">
-                {{ item.title }}
-              </h3>
-              <p class="news-item-summary">{{ item.summary }}</p>
-              <button
-                  class="news-read-more"
-                  type="button"
-                  @click.stop="openNewsModal(item)"
-              >
-                Read more
-              </button>
-            </li>
-          </ul>
-        </section>
       </div>
     </div>
 
-    <NewsArticleModal
-        :visible="newsModalOpen"
-        :article="activeNewsItem"
-        @close="closeNewsModal"
-    />
-
-    <!-- Video Modal -->
     <teleport to="body">
-    <div v-if="showModal" class="video-modal" @click.self="closeModal">
-      <div class="modal-content">
-        <!-- Landscape tip for mobile -->
-        <div class="landscape-tip" v-if="isMobile && !isLandscape">
-          <img src="/img/rotate_device.png" alt="Rotate Device" class="rotate-icon"/>
-          <p>Please rotate your device for the best viewing experience.</p>
+      <div v-if="showModal" class="video-modal" @click.self="closeModal">
+        <div class="modal-content">
+          <div class="landscape-tip" v-if="isMobile && !isLandscape">
+            <img src="/img/rotate_device.png" alt="Rotate Device" class="rotate-icon"/>
+            <p>Please rotate your device for the best viewing experience.</p>
+          </div>
+          <iframe
+              v-if="!isMobile || isLandscape"
+              :src="autoplayUrl"
+              frameborder="0"
+              allow="autoplay; encrypted-media"
+              allowfullscreen
+          ></iframe>
+          <button class="modal-close" @click="closeModal" aria-label="Close video">×</button>
         </div>
-        <iframe
-            v-if="!isMobile || isLandscape"
-            :src="autoplayUrl"
-            frameborder="0"
-            allow="autoplay; encrypted-media"
-            allowfullscreen
-            ref="videoIframe"
-        ></iframe>
-        <button class="modal-close" @click="closeModal" aria-label="Close video">×</button>
       </div>
-    </div>
     </teleport>
   </div>
 </template>
 
 <script>
-import NewsArticleModal from './subcomponents/NewsArticleModal.vue';
-
 export default {
   name: "VideoFeature",
-  components: {
-    NewsArticleModal
-  },
+  emits: ['next'],
   props: {
+    title: { type: String, default: '' },
     introTitle: { type: String, required: true },
-    introText: { type: Array, required: true },
+    welcomeText: { type: String, default: '' },
+    welcomeHint: { type: String, default: '' },
+    nextLabel: { type: String, default: 'Continue to Agrobots' },
     imgSource: { type: String, required: true },
     videoSource: { type: String, required: true },
-    thumbnail: { type: String, required: true },
-    newsItems: {
-      type: Array,
-      default: () => []
-    },
-    newsTitle: {
-      type: String,
-      default: 'Latest News'
-    }
+    thumbnail: { type: String, required: true }
   },
   data() {
     return {
       showModal: false,
       isLandscape: false,
-      isMobile: false,
-      newsModalOpen: false,
-      activeNewsItem: null,
-      bodyScrollLocks: 0
+      isMobile: false
     };
   },
   computed: {
     autoplayUrl() {
-      // Add autoplay param only when the modal is open
       if (!this.videoSource) return "";
       return this.videoSource.includes("?")
           ? this.videoSource + "&autoplay=1"
           : this.videoSource + "?autoplay=1";
-    },
-    displayedNewsItems() {
-      return this.newsItems;
     }
   },
   mounted() {
@@ -149,500 +89,59 @@ export default {
   beforeUnmount() {
     window.removeEventListener('resize', this.handleResize);
     window.removeEventListener('orientationchange', this.handleResize);
-    this.bodyScrollLocks = 0;
     document.body.style.overflow = '';
   },
   methods: {
     openModal() {
       this.showModal = true;
       this.handleResize();
-      this.lockBodyScroll();
+      document.body.style.overflow = 'hidden';
     },
     closeModal() {
       this.showModal = false;
-      this.unlockBodyScroll();
+      document.body.style.overflow = '';
     },
     handleResize() {
       this.isMobile = window.innerWidth <= 900;
-      // Check if the device is in landscape mode
       this.isLandscape = window.innerWidth > window.innerHeight;
-    },
-    openNewsModal(item) {
-      this.activeNewsItem = item;
-      this.newsModalOpen = true;
-      this.lockBodyScroll();
-    },
-    closeNewsModal() {
-      this.newsModalOpen = false;
-      this.activeNewsItem = null;
-      this.unlockBodyScroll();
-    },
-    lockBodyScroll() {
-      this.bodyScrollLocks += 1;
-      document.body.style.overflow = 'hidden';
-    },
-    unlockBodyScroll() {
-      this.bodyScrollLocks = Math.max(0, this.bodyScrollLocks - 1);
-      if (!this.bodyScrollLocks && !this.showModal && !this.newsModalOpen) {
-        document.body.style.overflow = '';
-      }
     }
   }
 };
 </script>
 
 <style scoped>
-img {
-  max-width: 100%;
-  height: auto;
-  object-fit: contain;
-}
-.video-feature-root {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: flex-start;
-  padding: 0;
-  overflow-x: hidden;
-  height: 100%;
-  min-height: 0;
-}
-
-.hero-layout {
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 1.75rem;
-  padding: 2rem 1.5rem 4rem;
-  box-sizing: border-box;
-  flex: 1;
-  min-height: 0;
-}
-
-.hero-brand-row {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  gap: 0.85rem;
-}
-
-.hero-logo {
-  width: clamp(140px, 14vw, 220px);
-  min-width: 120px;
-}
-
-.hero-title {
-  font-size: clamp(1.8rem, 2.6vw, 2.4rem);
-  font-weight: 600;
-  margin: 0;
-  letter-spacing: 0.01em;
-  text-align: center;
-}
-
-.hero-content-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 60%) minmax(240px, 40%);
-  gap: 1.5rem 2rem;
-  align-items: stretch;
-  flex: 1;
-  min-height: 0;
-}
-
-.hero-primary-column {
-  display: flex;
-  width: 100%;
-  align-self: stretch;
-  min-height: 0;
-  overflow-y: auto;
-  padding-right: 0.3rem;
-}
-
+.video-feature-root { width: 100%; height: 100%; overflow-x: hidden; }
+.hero-layout { width: 100%; padding: 2rem 1.5rem 4rem; box-sizing: border-box; }
+.hero-brand-row { display: flex; flex-direction: column; align-items: center; gap: .85rem; text-align: center; }
+.hero-logo { width: clamp(140px, 14vw, 220px); }
+.hero-title { font-size: clamp(1.8rem, 2.6vw, 2.4rem); margin: 0; }
+.hero-content-grid { display: grid; grid-template-columns: 1fr; }
+.hero-primary-column { width: 100%; }
 .hero-intro-text {
-  background: var(--backgroundDarkTranslucent, rgba(30, 30, 30, 0.95));
-  border-radius: 16px;
-  padding: 1.75rem 2rem;
-  font-size: 1.08rem;
-  line-height: 1.7;
-  color: var(--textLight, #eee);
-  box-shadow: 0 15px 45px rgba(0, 0, 0, 0.35);
-  width: 100%;
+  background: var(--backgroundDarkTranslucent, rgba(30,30,30,.95));
+  border-radius: 16px; padding: 1.5rem; max-width: 960px; margin: 0 auto;
 }
-
-.hero-intro-text::after {
-  content: '';
-  display: block;
-  clear: both;
-}
-
-.intro-text-body {
-  display: block;
-}
-
-.hero-intro-text p {
-  margin: 0;
-}
-
-.intro-text-body p + p {
-  margin-top: 1rem;
-}
-
-.hero-media-inline {
-  float: right;
-  width: min(360px, 40%);
-  margin-left: 1.5rem;
-  margin-bottom: 1rem;
-}
-
-.hero-media-inline .video-card {
-  width: 100%;
-}
-
-.video-card {
-  position: relative;
-  aspect-ratio: 16 / 9;
-  width: min(500px, 100%);
-  cursor: pointer;
-  border-radius: 16px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
-  overflow: hidden;
-  background: #222;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.video-card img {
-  width: 100%;
-  height: auto;
-  object-fit: cover;
-  display: block;
-}
-
+.intro-kicker { text-transform: uppercase; letter-spacing: .16em; color: var(--accent, #ffd54f); font-size: .78rem; }
+.welcome-title { margin: .35rem 0 0; font-size: clamp(1.35rem, 2vw, 2rem); }
+.welcome-text { margin: .75rem 0 0; font-size: 1.05rem; line-height: 1.5; }
+.welcome-hint { margin: .65rem 0 0; opacity: .86; }
+.hero-media-inline { margin-top: 1rem; }
+.video-card { position: relative; cursor: pointer; border-radius: 14px; overflow: hidden; border: 1px solid rgba(255,255,255,.2); }
+.video-card img { width: 100%; display: block; }
 .yt-play-btn {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  display: block;
-  width: 64px;
-  height: 64px;
-  background: rgba(255,0,0,0.38);
-  border-radius: 50%;
-  pointer-events: none;
-  box-shadow: 0 2px 8px #000b;
-  transition: filter 0.12s;
+  position: absolute; inset: 50% auto auto 50%; transform: translate(-50%, -50%);
+  width: 64px; height: 46px; background: rgba(255,0,0,.88); border-radius: 12px;
 }
-
-.video-card:hover .yt-play-btn {
-  filter: brightness(1.1) drop-shadow(0 0 10px var(--accent));
+.yt-play-btn::before {
+  content: ''; position: absolute; left: 24px; top: 13px; width: 0; height: 0;
+  border-left: 16px solid #fff; border-top: 10px solid transparent; border-bottom: 10px solid transparent;
 }
-
-.yt-play-btn::after {
-  content: "";
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-40%, -50%);
-  width: 26px;
-  height: 32px;
-  background: #ffffff;
-  border-radius: 18% 45% 45% 18%/25% 50% 50% 25%;
-  clip-path: polygon(0% 0%, 100% 50%, 0% 100%);
-}
-
-.news-panel {
-  background: rgba(18, 31, 27, 0.85);
-  border-radius: 18px;
-  padding: 1.25rem 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1.1rem;
-  border-left: 3px solid var(--primary, #0b874b);
-  height: 100%;
-  align-self: stretch;
-  min-height: 0;
-  overflow-y: auto;
-  padding-right: 0.3rem;
-}
-
-.news-panel-header {
-  display: flex;
-  justify-content: flex-start;
-  align-items: baseline;
-}
-
-.news-panel-title {
-  margin: 0;
-  font-size: 1.35rem;
-  letter-spacing: 0.02em;
-}
-
-.news-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 1.15rem;
-  flex: 1;
-  padding-right: 0.4rem;
-  min-height: 0;
-}
-
-.news-item {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  padding-bottom: 0.8rem;
-  border-bottom: 1px solid rgba(255,255,255,0.08);
-  cursor: pointer;
-}
-
-.news-item:last-child {
-  border-bottom: none;
-  padding-bottom: 0;
-}
-
-.news-item:focus-visible {
-  outline: 2px solid var(--accent, #36c284);
-  outline-offset: 4px;
-}
-
-.news-meta {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.75rem;
-  font-size: 0.85rem;
-  color: rgba(255,255,255,0.7);
-}
-
-.news-meta-left {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  min-height: 1.2rem;
-}
-
-.news-meta-right {
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
-  font-size: 0.82rem;
-  color: rgba(255,255,255,0.75);
-  flex-shrink: 0;
-  text-align: right;
-}
-
-.news-date {
-  font-weight: 600;
-  letter-spacing: 0.02em;
-}
-
-.news-location {
-  color: rgba(255,255,255,0.65);
-  white-space: nowrap;
-  font-weight: 500;
-}
-
-.news-location::before {
-  content: '•';
-  margin-right: 0.35rem;
-  opacity: 0.65;
-}
-
-.news-tag {
-  padding: 0.05rem 0.55rem;
-  border-radius: 999px;
-  border: 1px solid rgba(255,255,255,0.35);
-  font-size: 0.75rem;
-}
-
-.news-item-title {
-  margin: 0;
-  font-size: 1.05rem;
-}
-
-.news-item-title a {
-  color: var(--textLight, #fff);
-  text-decoration: none;
-}
-
-.news-item-title a:hover {
-  text-decoration: underline;
-}
-
-.news-item-summary {
-  margin: 0;
-  font-size: 0.95rem;
-  color: rgba(255,255,255,0.85);
-}
-
-.news-read-more {
-  margin-top: 0.35rem;
-  padding: 0.35rem 0.9rem;
-  border-radius: 999px;
-  border: 1px solid var(--accent, #ffd54f);
-  background: transparent;
-  color: var(--accent, #ffd54f);
-  font-size: 0.78rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
-  align-self: flex-start;
-}
-
-.news-read-more:hover,
-.news-read-more:focus-visible {
-  background: var(--accent, #ffd54f);
-  color: #1c1c1c;
-  transform: translateY(-1px);
-  outline: none;
-}
-
-/* Modal styles: Use dynamic viewport for mobile browser chrome */
-.video-modal {
-  position: fixed;
-  top: 0; left: 0;
-  width: 100vw;
-  height: 100dvh;      /* <-- Use dynamic viewport height */
-  max-height: 100dvh;
-  background: rgba(24,24,24,0.98);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 2100;
-  animation: fadeInModal 0.19s cubic-bezier(.44,.23,.58,.85);
-  /* fallback for old browsers */
-  /* height: 100vh; */
-}
-
-@supports not (height: 100dvh) {
-  .video-modal {
-    height: 100vh;
-    max-height: 100vh;
-  }
-}
-
-@keyframes fadeInModal {
-  0% { opacity: 0; }
-  100% { opacity: 1; }
-}
-.modal-content {
-  position: relative;
-  background: transparent;
-  border-radius: 16px;
-  padding: 0;
-  width: 90vw;
-  max-width: 900px;
-  aspect-ratio: 16/9;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 12px 64px #000a;
-  overflow: hidden;
-
-  /* Add top/bottom margin to avoid browser UI overlays */
-  margin-top: 3vw;
-  margin-bottom: 3vw;
-}
-
-.modal-content iframe {
-  width: 100%;
-  height: 100%;
-  border: none;
-  background: #222;
-}
-
-.modal-close {
-  position: absolute;
-  top: 12px;
-  right: 18px;
-  font-size: 2.2rem;
-  background: none;
-  color: #fff;
-  border: none;
-  cursor: pointer;
-  z-index: 20;
-  filter: drop-shadow(0 1px 1px #000a);
-  opacity: 0.9;
-}
-.modal-close:hover { opacity: 1; }
-
-.landscape-tip {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  color: #fff9;
-  font-size: 1.18rem;
-  width: 90vw;
-  height: 55vw;
-  background: rgba(20,20,20,0.99);
-  position: absolute;
-  top: 0; left: 0;
-  z-index: 22;
-  border-radius: 18px;
-}
-.rotate-icon {
-  width: 58px;
-  margin-bottom: 1rem;
-  opacity: 0.9;
-}
-
-/* Responsive adjustments */
-@media (max-width: 900px) {
-  .hero-layout {
-    padding: 1.5rem 1rem 3rem;
-    gap: 1.5rem;
-    height: auto;
-  }
-  .hero-content-grid {
-    grid-template-columns: 1fr;
-    min-height: auto;
-  }
-  .hero-logo {
-    width: min(240px, 55vw);
-    min-width: 120px;
-    margin-bottom: 0.5rem;
-  }
-  .hero-primary-column,
-  .news-panel {
-    overflow: visible;
-    padding-right: 0;
-  }
-  .hero-media-inline {
-    float: none;
-    width: 100%;
-    margin: 0 0 1rem 0;
-  }
-  .video-card {
-    width: 100%;
-  }
-  .hero-intro-text,
-  .news-panel {
-    padding: 1.2rem 1.3rem;
-  }
-  .modal-content {
-    width: 99vw;
-    max-width: 99vw;
-    min-width: 0;
-    aspect-ratio: 16/9;
-    border-radius: 13px;
-    margin-top: 2vw;
-    margin-bottom: 2vw;
-  }
-  .landscape-tip {
-    width: 99vw;
-    height: 60vw;
-    font-size: 1rem;
-    border-radius: 13px;
-    text-align: center;
-  }
-}
+.hero-actions { margin-top: 1rem; display: flex; justify-content: flex-end; }
+.primary-action { border: none; border-radius: 999px; padding: .7rem 1.2rem; cursor: pointer; background: var(--primary, #0b874b); color: #fff; }
+.video-modal { position: fixed; inset: 0; background: rgba(0,0,0,.82); display: flex; align-items: center; justify-content: center; z-index: 3000; }
+.modal-content { width: min(92vw, 1020px); height: min(84vh, 620px); position: relative; background: #000; border-radius: 14px; overflow: hidden; }
+.modal-content iframe { width: 100%; height: 100%; }
+.modal-close { position: absolute; top: 10px; right: 12px; background: rgba(0,0,0,.6); color: #fff; border: none; font-size: 2rem; cursor: pointer; }
+.landscape-tip { display: flex; flex-direction: column; align-items: center; justify-content: center; height: 100%; color: #fff; }
+.rotate-icon { width: 72px; margin-bottom: .8rem; }
 </style>

--- a/src/slides/agrobots.js
+++ b/src/slides/agrobots.js
@@ -1,0 +1,28 @@
+import introSlide from './intro';
+
+export default {
+  name: 'agrobots',
+  component: 'AgrobotsIntro',
+  content: {
+    en: {
+      title: 'Agrobots',
+      slideTitle: 'Agrobots',
+      introText: introSlide.content.en.introText,
+      images: [
+        { src: '/img/impact_main.png', alt: 'Agrobots impact overview' },
+        { src: '/img/biorome_day.png', alt: 'Biorome daytime view' },
+        { src: '/img/biorome_night.png', alt: 'Biorome nighttime view' }
+      ]
+    },
+    es: {
+      title: 'Agrobots',
+      slideTitle: 'Agrobots',
+      introText: introSlide.content.es.introText,
+      images: [
+        { src: '/img/impact_main.png', alt: 'Resumen de impacto de Agrobots' },
+        { src: '/img/biorome_day.png', alt: 'Vista diurna del biorome' },
+        { src: '/img/biorome_night.png', alt: 'Vista nocturna del biorome' }
+      ]
+    }
+  }
+};

--- a/src/slides/intro.js
+++ b/src/slides/intro.js
@@ -4,7 +4,10 @@ export default {
     content: {
         en: {
             title: 'Welcome',
-            introTitle: "Transforming Agriculture with LandOS",
+            introTitle: "Welcome to Agrobots",
+            welcomeText: "Agrobots turns degraded or underused land into intelligent, regenerative production systems powered by LandOS.",
+            welcomeHint: "Watch the short video below, then continue to the Agrobots slide for the full introduction.",
+            nextLabel: "Continue to Agrobots",
             thumbnail: "/img/thumbnail.png",
             introText: [
                 "Agrobots is leading the transition to Agriculture 4.0 with Terrain Management as a Service (TMaaS). We transform underutilized or degraded land into intelligent, self-optimizing ecosystems using AI, robotics, and modular design.",
@@ -108,7 +111,10 @@ export default {
 
         es: {
             title: 'Bienvenidos',
-            introTitle: "Transformando la Agricultura con LandOS",
+            introTitle: "Bienvenidos a Agrobots",
+            welcomeText: "Agrobots transforma terrenos degradados o infrautilizados en sistemas productivos regenerativos e inteligentes con LandOS.",
+            welcomeHint: "Mira el video breve de abajo y continúa a la diapositiva Agrobots para ver la introducción completa.",
+            nextLabel: "Continuar a Agrobots",
             thumbnail: "/img/thumbnail.png",
             introText: [
                 "Agrobots lidera la transición hacia la Agricultura 4.0 con un modelo de Gestión de Terreno como Servicio (TMaaS). Convertimos terrenos infrautilizados o degradados en ecosistemas inteligentes y auto-optimizados mediante IA, robótica y un diseño modular.",


### PR DESCRIPTION
### Motivation
- Introduce a dedicated Agrobots intro slide to present images and localized intro text separate from the video landing content.
- Surface headline news in the site footer via a ticker and a modal list so users can discover news without leaving the main flow.
- Simplify and decouple the video intro component to emit navigation events and remove embedded news UI responsibilities.

### Description
- Added a new component `src/components/AgrobotsIntro.vue` that renders a text panel and an images aside with responsive styles.
- Added a new slide configuration `src/slides/agrobots.js` and inserted it into the `slides` array in `src/components/SlideDeck.vue`, and adjusted `componentEventMap` to forward `next` for the intro slide.
- Extended `SlideDeck.vue` to include a footer news ticker button, a teleported news list modal, `NewsArticleModal` wiring, computed `footerNewsItems`/`tickerText`, and methods `toggleNewsModal`, `openNewsArticle`, and `closeNewsArticle`.
- Refactored `src/components/VideoFeature.vue` to emit a `next` event, accept `welcomeText`, `welcomeHint`, and `nextLabel` props, remove its internal news list and modal logic, simplify body scroll locking by toggling `document.body.style.overflow`, and update markup/CSS for the revised hero layout and modal.
- Updated `src/slides/intro.js` localized content to include new `welcomeText`, `welcomeHint`, and `nextLabel` strings used by the refactored video slide.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9a4cb6e508327a2399f38aea4b42c)